### PR TITLE
Update convert_to_sharded_events.py

### DIFF
--- a/scripts/extraction/split_and_shard_patients.py
+++ b/scripts/extraction/split_and_shard_patients.py
@@ -60,7 +60,7 @@ def main(cfg: DictConfig):
     logger.info(f"Joining all patient IDs from {len(dfs)} dataframes")
     patient_ids = (
         pl.concat(dfs)
-        .select(pl.col("patient_id").unique())
+        .select(pl.col("patient_id").drop_nulls().drop_nans().unique())
         .collect(streaming=True)["patient_id"]
         .to_numpy(use_pyarrow=True)
     )


### PR DESCRIPTION
Fixes Issue #25 

Specifically we drop patient_ids with nan and null values in `scripts/extraction/split_and_shard_patients.py`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced data processing to handle patient IDs more robustly by dropping nulls and NaNs before selecting unique IDs.

- **Refactor**
	- Modified data type conversion logic to be less strict, allowing for smoother handling of varying data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->